### PR TITLE
Update fly.toml to match default server port

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -15,7 +15,7 @@ processes = []
 
 [[services]]
   http_checks = []
-  internal_port = 8080
+  internal_port = 3000
   processes = ["app"]
   protocol = "tcp"
   script_checks = []


### PR DESCRIPTION
In my freshly installed remix installation, the default server port was 3000.
Which resulted in the following error:
```
***v0 failed - Failed due to unhealthy allocations - no stable job version to auto revert to and deploying as v1
```
If this is true for all users, setting the port on 3000 might make more sense.